### PR TITLE
add quick fix with todo comment

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,9 +18,10 @@ async fn fetch(
     headers.set("x-content-type-options", "nosniff")?;
     headers.set("referrer-policy", "no-referrer")?;
     headers.set("permissions-policy", "microphone 'none'")?;
+    // TODO: add allow list for CSP to be passed in via an environment variable
     headers.set(
         "content-security-policy",
-        "default-src 'self' cloudflareinsights.com *.cloudflareinsights.com; img-src 'self' *.cloudinary.com; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com",
+        "default-src 'self' cloudflareinsights.com *.cloudflareinsights.com; img-src 'self' *.cloudinary.com; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; script-src sha-256-1jAmyYXcRq6zFldLe/GCgIDJBiOONdXjTLgEFMDnDSM= sha-256-IMJnu+yLntfBwXeZW5hFOsX+Q/bWLTx4zxSKGwHWp1I=",
     )?;
     headers.set("permissions-policy", "microphone=(), geolocation=()")?;
     headers.set("access-control-allow-origin", &origin)?;


### PR DESCRIPTION
add a sha-256 hash for each of my inline scripts as a quick fix.

https://content-security-policy.com/hash/